### PR TITLE
tt-bio improve/round2: correctness & parsing fixes

### DIFF
--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -60,3 +60,14 @@ def test_msa_id_on_non_protein_rejected(tmp_path):
     p = _fasta(tmp_path, ">A|dna|somemsa\nACGT\n")
     with pytest.raises(ValueError, match="MSA_ID is only allowed for proteins"):
         parse_fasta(p, ccd={}, mol_dir=tmp_path)
+
+
+def test_chain_label_bijective_base26():
+    """Chain ids must stay unique past 26 chains (the old %26 / chr() schemes collided or ran
+    past 'Z', silently corrupting multi-chain output)."""
+    from tt_bio.main import _chain_label
+
+    assert [_chain_label(n) for n in range(26)] == [chr(65 + n) for n in range(26)]  # parity <26
+    assert _chain_label(26) == "AA" and _chain_label(27) == "AB" and _chain_label(52) == "BA"
+    labels = [_chain_label(n) for n in range(60)]
+    assert len(set(labels)) == 60  # all unique

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -1,0 +1,34 @@
+"""Regression tests for input validation / normalization on the fold path.
+
+Two silent-corruption cases these guard against:
+  * an empty (or whitespace-only) polymer sequence flowing unchecked into featurization and
+    crashing deep in the model with a non-actionable message;
+  * embedded whitespace in a Protenix sequence tokenizing to extra UNK residues, silently
+    lengthening the chain (the Boltz and ESMFold parsers already strip; Protenix did not).
+
+Host-only — no device, no checkpoints.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tt_bio.data.parse import parse_boltz_schema
+from tt_bio.protenix_data import aatype_from_sequence, seq_to_restype
+
+
+@pytest.mark.parametrize("seq", ["", "   ", "\n\t"])
+def test_empty_polymer_sequence_rejected(seq):
+    schema = {"version": 1, "sequences": [{"protein": {"id": "A", "sequence": seq}}]}
+    with pytest.raises(ValueError, match="Empty protein sequence for chain 'A'"):
+        parse_boltz_schema("t", schema, ccd={})
+
+
+def test_protenix_strips_whitespace_in_sequence():
+    # spaces / tabs / newlines must not become extra residues
+    assert torch.equal(seq_to_restype("A R N", "protein"), seq_to_restype("ARN", "protein"))
+    assert torch.equal(seq_to_restype("MK\n V\tL", "protein"), seq_to_restype("MKVL", "protein"))
+    assert seq_to_restype("A C G", "rna").shape[0] == 3
+    # a whitespace-free sequence is unchanged (does not perturb the validated path)
+    seq = "MKVLINSTQ"
+    assert torch.equal(seq_to_restype(seq, "protein"), aatype_from_sequence(seq))

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -17,6 +17,12 @@ from tt_bio.data.parse import parse_boltz_schema
 from tt_bio.protenix_data import aatype_from_sequence, seq_to_restype
 
 
+def _fasta(tmp_path, txt):
+    p = tmp_path / "in.fasta"
+    p.write_text(txt)
+    return p
+
+
 @pytest.mark.parametrize("seq", ["", "   ", "\n\t"])
 def test_empty_polymer_sequence_rejected(seq):
     schema = {"version": 1, "sequences": [{"protein": {"id": "A", "sequence": seq}}]}
@@ -32,3 +38,25 @@ def test_protenix_strips_whitespace_in_sequence():
     # a whitespace-free sequence is unchanged (does not perturb the validated path)
     seq = "MKVLINSTQ"
     assert torch.equal(seq_to_restype(seq, "protein"), aatype_from_sequence(seq))
+
+
+def test_blank_chain_id_is_auto_assigned_not_dropped(tmp_path):
+    """A record with a blank leading id (``>|protein``) must yield a chain with an auto-assigned
+    id, not be silently dropped (which surfaces later as a misleading 'no sequences' error)."""
+    from tt_bio.main import _read_bio_chains, _read_protein_chains
+
+    p = _fasta(tmp_path, ">|protein\nMKVL\n")
+    prot = _read_protein_chains(p)
+    assert len(prot) == 1 and prot[0][0] == "A" and prot[0][1] == "MKVL"
+    bio = _read_bio_chains(p)
+    assert len(bio) == 1 and bio[0][0] == "A"
+
+
+def test_msa_id_on_non_protein_rejected(tmp_path):
+    """The MSA-id-only-on-proteins check was an ``assert`` (silently disabled under ``python -O``);
+    it must be a real raise regardless of optimization level."""
+    from tt_bio.data.parse import parse_fasta
+
+    p = _fasta(tmp_path, ">A|dna|somemsa\nACGT\n")
+    with pytest.raises(ValueError, match="MSA_ID is only allowed for proteins"):
+        parse_fasta(p, ccd={}, mol_dir=tmp_path)

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -39,3 +39,21 @@ def test_num_devices_and_default(two_cards):
     assert runtime.detect_tenstorrent_devices(None, 1, max_workers=10) == [0]
     assert runtime.detect_tenstorrent_devices(None, 0, max_workers=10) == [0, 1]
     assert runtime.detect_tenstorrent_devices(None, 0, max_workers=1) == [0]  # max_workers cap honored
+
+
+def test_duplicate_stem_inputs_rejected(tmp_path):
+    (tmp_path / "target.fasta").write_text(">A|protein\nMK\n")
+    (tmp_path / "target.yaml").write_text("sequences: []\n")
+    struct = tmp_path / "structures"
+    struct.mkdir()
+    with pytest.raises(ValueError, match="share a name stem"):
+        runtime.discover_jobs(tmp_path, struct, "cif", override=True)
+
+
+def test_unique_stems_discovered(tmp_path):
+    (tmp_path / "a.fasta").write_text(">A|protein\nMK\n")
+    (tmp_path / "b.yaml").write_text("sequences: []\n")
+    struct = tmp_path / "structures"
+    struct.mkdir()
+    jobs = runtime.discover_jobs(tmp_path, struct, "cif", override=True)
+    assert sorted(j.id for j in jobs) == ["a", "b"]

--- a/tests/test_runtime.py
+++ b/tests/test_runtime.py
@@ -1,0 +1,41 @@
+"""Regression: detect_tenstorrent_devices must validate an explicit --device_ids against the
+cards actually present, raising a clear error instead of passing a bad id straight through to a
+deep, opaque ttnn device-open crash. Host-only; device discovery is monkeypatched (no hardware).
+"""
+from __future__ import annotations
+
+import pytest
+
+from tt_bio import runtime
+
+
+@pytest.fixture
+def two_cards(monkeypatch):
+    monkeypatch.setattr(runtime.glob, "glob",
+                        lambda pat: ["/dev/tenstorrent/0", "/dev/tenstorrent/1"])
+    return None
+
+
+def test_explicit_ids_selected_when_present(two_cards):
+    assert runtime.detect_tenstorrent_devices("0,1", 0, max_workers=10) == [0, 1]
+    assert runtime.detect_tenstorrent_devices("1", 0, max_workers=10) == [1]
+
+
+def test_missing_id_raises_clear_error(two_cards):
+    with pytest.raises(ValueError) as ei:
+        runtime.detect_tenstorrent_devices("7", 0, max_workers=10)
+    msg = str(ei.value)
+    assert "7" in msg and "0, 1" in msg  # names the bad id and the available ones
+
+
+def test_missing_id_when_no_cards(monkeypatch):
+    monkeypatch.setattr(runtime.glob, "glob", lambda pat: [])
+    with pytest.raises(ValueError) as ei:
+        runtime.detect_tenstorrent_devices("0", 0, max_workers=10)
+    assert "none detected" in str(ei.value)
+
+
+def test_num_devices_and_default(two_cards):
+    assert runtime.detect_tenstorrent_devices(None, 1, max_workers=10) == [0]
+    assert runtime.detect_tenstorrent_devices(None, 0, max_workers=10) == [0, 1]
+    assert runtime.detect_tenstorrent_devices(None, 0, max_workers=1) == [0]  # max_workers cap honored

--- a/tt_bio/data/parse.py
+++ b/tt_bio/data/parse.py
@@ -2925,6 +2925,12 @@ def parse_boltz_schema(  # noqa: C901, PLR0915, PLR0912
             # garbage. (SMILES, which is case-sensitive, is a ligand and never
             # reaches this polymer branch.)
             raw_seq = "".join(items[0][entity_type]["sequence"].split()).upper()
+            if not raw_seq:
+                raise ValueError(
+                    f"Empty {entity_type} sequence for chain "
+                    f"{items[0][entity_type].get('id')!r}. Every polymer entity needs a "
+                    "non-empty sequence (whitespace-only sequences are treated as empty)."
+                )
             entity_to_seq[entity_id] = raw_seq
 
             # Convert sequence to tokens

--- a/tt_bio/data/parse.py
+++ b/tt_bio/data/parse.py
@@ -363,7 +363,8 @@ def parse_fasta(  # noqa: C901, PLR0912
             raise ValueError(msg)
 
         header = seq_record.id.split("|")
-        assert len(header) >= 2, f"Invalid record id: {seq_record.id}"
+        if len(header) < 2:
+            raise ValueError(f"Invalid record id: {seq_record.id}")
 
         chain_id, entity_type = header[:2]
         if entity_type.lower() not in {"protein", "dna", "rna", "ccd", "smiles"}:
@@ -383,9 +384,8 @@ def parse_fasta(  # noqa: C901, PLR0912
         header = seq_record.id.split("|")
         chain_id, entity_type = header[:2]
         if len(header) == 3 and header[2] != "":
-            assert entity_type.lower() == "protein", (
-                "MSA_ID is only allowed for proteins"
-            )
+            if entity_type.lower() != "protein":
+                raise ValueError("MSA_ID is only allowed for proteins")
             msa_id = header[2]
         else:
             msa_id = None

--- a/tt_bio/main.py
+++ b/tt_bio/main.py
@@ -1443,7 +1443,9 @@ def _read_protein_chains(path):
     if suffix in (".fa", ".fas", ".fasta"):
         cid, buf, msa = None, [], None
         def flush():
-            if cid and buf:
+            # cid is None for a skipped (non-protein) record; a blank id ("") is a real protein
+            # chain whose id we auto-assign below — gate on `is not None` so it isn't dropped.
+            if cid is not None and buf:
                 for c in cid.split(","):
                     chains.append((c.strip() or chr(65 + len(chains)), "".join(buf), msa))
         for line in path.read_text().splitlines():
@@ -1493,7 +1495,9 @@ def _read_bio_chains(path):
     if suffix in (".fa", ".fas", ".fasta"):
         cid, buf, msa, mt = None, [], None, "protein"
         def flush():
-            if cid and buf:
+            # cid is None for a skipped/unknown record; a blank id ("") is a real chain whose id
+            # we auto-assign below — gate on `is not None` so it isn't silently dropped.
+            if cid is not None and buf:
                 seq = "".join(buf)
                 seq = ("CCD_" + seq.upper()) if mt == "_ccd" else seq   # ccd code -> CCD_ spec
                 mtype = "ligand" if mt in ("_ccd", "ligand") else mt

--- a/tt_bio/main.py
+++ b/tt_bio/main.py
@@ -1428,6 +1428,19 @@ def msa_server_cmd(listen, msa_db_path, cache_dir, use_envdb, max_concurrent, to
 # ---------------------------------------------------------------------------
 # ESMFold2 (--model esmfold2): single-sequence, protein-only, on-device ttnn.
 # ---------------------------------------------------------------------------
+def _chain_label(n: int) -> str:
+    """Chain id for the n-th chain (0-indexed): A..Z, then AA, AB, ... (bijective base-26).
+    Identical to the old ``chr(65 + n)`` for n < 26, but never collides or runs past 'Z' for a
+    larger complex — an index-mod-26 or bare ``chr()`` scheme produced duplicate or non-alphabetic
+    chain ids there, silently corrupting the written structure."""
+    s = ""
+    n += 1
+    while n:
+        n, r = divmod(n - 1, 26)
+        s = chr(ord("A") + r) + s
+    return s
+
+
 def _read_protein_chains(path):
     """Extract [(chain_id, sequence, msa_spec)] protein entries from FASTA/YAML.
 
@@ -1447,7 +1460,7 @@ def _read_protein_chains(path):
             # chain whose id we auto-assign below — gate on `is not None` so it isn't dropped.
             if cid is not None and buf:
                 for c in cid.split(","):
-                    chains.append((c.strip() or chr(65 + len(chains)), "".join(buf), msa))
+                    chains.append((c.strip() or _chain_label(len(chains)), "".join(buf), msa))
         for line in path.read_text().splitlines():
             line = line.strip()
             if line.startswith(">"):
@@ -1502,7 +1515,7 @@ def _read_bio_chains(path):
                 seq = ("CCD_" + seq.upper()) if mt == "_ccd" else seq   # ccd code -> CCD_ spec
                 mtype = "ligand" if mt in ("_ccd", "ligand") else mt
                 for c in cid.split(","):
-                    chains.append((c.strip() or chr(65 + len(chains)), seq, msa, mtype))
+                    chains.append((c.strip() or _chain_label(len(chains)), seq, msa, mtype))
         for line in path.read_text().splitlines():
             line = line.strip()
             if line.startswith(">"):
@@ -1648,7 +1661,7 @@ def _write_protenix_structure(coords, feats, aatype, outpath, output_format, b_f
     arr.b_factor[:] = b_factors.numpy().astype("float32") if b_factors is not None else 0.0
     for i in range(coords.shape[0]):
         t = a2t[i]
-        arr.chain_id[i] = chr(ord("A") + int(asym[t]) % 26)
+        arr.chain_id[i] = _chain_label(int(asym[t]))
         arr.res_id[i] = int(resid[t])
         arr.res_name[i] = "LIG" if is_lig_tok[t] else resname[t]
         arr.atom_name[i] = names[i]

--- a/tt_bio/protenix_data.py
+++ b/tt_bio/protenix_data.py
@@ -365,7 +365,13 @@ _NA_PYRIMIDINES = {"C", "U", "DC", "DT"}
 
 def seq_to_restype(seq: str, mol_type: str = "protein") -> torch.Tensor:
     """One-letter sequence -> 32-class restype indices for the given modality
-    (protein 0-20, RNA 21-25, DNA 26-30); unknown letters map to the modality's UNK."""
+    (protein 0-20, RNA 21-25, DNA 26-30); unknown letters map to the modality's UNK.
+
+    Whitespace is stripped first: a sequence pasted from a formatted source carries spaces/
+    newlines, and without this each space would tokenize to UNK and silently add a residue,
+    shifting the whole chain. Matches the Boltz and ESMFold parsers, which also strip. A
+    whitespace-free sequence is unchanged, so this does not perturb the validated path."""
+    seq = "".join(seq.split())
     if mol_type == "protein":
         return aatype_from_sequence(seq)
     table, unk = (_RNA_LETTER_IDX, 25) if mol_type == "rna" else (_DNA_LETTER_IDX, 30)

--- a/tt_bio/runtime.py
+++ b/tt_bio/runtime.py
@@ -55,10 +55,24 @@ def discover_jobs(data: Path, structure_dir: Path, output_format: str, override:
 
 
 def detect_tenstorrent_devices(device_ids: str | None, num_devices: int, max_workers: int) -> list[int]:
-    """Return TT device IDs selected for this run without importing ttnn."""
+    """Return TT device IDs selected for this run without importing ttnn.
+
+    An explicit ``device_ids`` is validated against the cards actually present under
+    ``/dev/tenstorrent``: a request for a device that isn't there (a typo like ``--device_ids 7``
+    on a two-card box) raises a clear error naming the available ids, instead of passing straight
+    through and failing much later with an opaque low-level device-open error.
+    """
     all_devices = sorted(int(p.rsplit("/", 1)[-1]) for p in glob.glob("/dev/tenstorrent/[0-9]*"))
     if device_ids:
-        devices = [int(d.strip()) for d in device_ids.split(",") if d.strip()]
+        requested = [int(d.strip()) for d in device_ids.split(",") if d.strip()]
+        missing = [d for d in requested if d not in all_devices]
+        if missing:
+            avail = ", ".join(map(str, all_devices)) if all_devices else "none detected"
+            raise ValueError(
+                f"Requested Tenstorrent device id(s) {missing} not available "
+                f"(present: {avail}). Fix --device_ids, or leave it unset to use all cards."
+            )
+        devices = requested
     elif num_devices > 0:
         devices = all_devices[:num_devices]
     else:

--- a/tt_bio/runtime.py
+++ b/tt_bio/runtime.py
@@ -49,6 +49,21 @@ def discover_jobs(data: Path, structure_dir: Path, output_format: str, override:
         p for p in (data.glob("*") if data.is_dir() else [data])
         if p.suffix.lower() in INPUT_SUFFIXES
     )
+    # A job is identified by its file stem (used for output filenames AND result/failure keys),
+    # so two inputs sharing a stem — e.g. target.fasta and target.yaml — would silently overwrite
+    # each other's output and merge into one result. Refuse the ambiguous case with a clear message
+    # rather than lose a prediction. Checked on the full input set (before the resume filter).
+    by_stem: dict[str, list[Path]] = {}
+    for p in files:
+        by_stem.setdefault(p.stem, []).append(p)
+    dups = {stem: ps for stem, ps in by_stem.items() if len(ps) > 1}
+    if dups:
+        detail = "; ".join(f"'{stem}' <- {', '.join(pp.name for pp in ps)}"
+                           for stem, ps in sorted(dups.items()))
+        raise ValueError(
+            "Input files share a name stem and would overwrite each other's output. "
+            f"Rename so each input has a unique stem ({detail})."
+        )
     if not override:
         files = [p for p in files if not (structure_dir / f"{p.stem}.{output_format}").exists()]
     return [PredictionJob(id=p.stem, path=p) for p in files]


### PR DESCRIPTION
## Summary
Five correctness and robustness fixes for parsing and runtime validation:
- Unique chain labels via bijective base-26 for 26+ chains
- Reject input files with duplicate name stems
- Don't drop blank-id FASTA chains; convert fragile asserts to raises
- Strip whitespace in Protenix tokenizer; reject empty polymer sequences
- Validate explicit --device_ids against present TT cards

Parity-tested, branch-only.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>